### PR TITLE
Add parameter for ingress protocol annotation key name

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -908,9 +908,9 @@ metadata:
     {{ end }}
   annotations:
     {{ if eq .containerPort.tls true }}
-    ingress.kubernetes.io/protocol: "https"
+    {{ .root.Values.ingress.backendProtocolAnnotationKey }}: "https"
     {{ else }}
-    ingress.kubernetes.io/protocol: "http"
+    {{ .root.Values.ingress.backendProtocolAnnotationKey }}: "http"
     {{ end }}
 
     {{ if .root.Values.ingress.metadata.annotations }}

--- a/values.yaml
+++ b/values.yaml
@@ -221,6 +221,10 @@ ingress:
   # into the ingress object
   pathType: ""
 
+  # name of annotation key that tells the ingress controller
+  # if backend is http or https
+  backendProtocolAnnotationKey: "ingress.kubernetes.io"
+
   # the ingressClassName required for networking.k8s.io/v1
   # otherwise defaults to nothing (empty string), won't be applied
   # this CANNOT co-exist w/ annotation "kubernetes.io/ingress.class"


### PR DESCRIPTION
Customizable value to set the ingress annotation key name for backend protocol.  Need this to support other ingress controllers.  For example, ingress-nginx, which uses `nginx.ingress.kubernetes.io/backend-protocol` rather than `ingress.kubernetes.io`.