### PR TITLE
Update apiVersion for PodDisruptionBudget

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -541,7 +541,7 @@ spec:
 ---------------------------------------------------------------------- */}}
 ---
 {{- if .Values.disruptionBudget.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   namespace: "{{ $.Release.Namespace }}"


### PR DESCRIPTION
apiVersion `policy/v1beta1` is deprecated and removed.  Updated to `policy/v1` for PodDisruptionBudget template